### PR TITLE
no wifis found on Ubuntu 14.04, nmcl tool version 0.9.8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Maybe you have a SoftAP-based IoT toy, and you just need to make a thin download
 
   //  Try scanning for access points:
   WiFiControl.scanForWiFi( function(err, response) {
-    if (err) console.log(error);
+    if (err) console.log(err);
     console.log(response);
   });
 ```

--- a/lib/wifi-control.js
+++ b/lib/wifi-control.js
@@ -242,11 +242,11 @@
         if (process.platform === "linux") {
           scanResults = execSync("nmcli -m multiline device wifi list");
           networks = [];
-          ref = scanResults.split('*:');
+          ref = scanResults.split('\nSSID:');
           for (c = j = 0, len = ref.length; j < len; c = ++j) {
             nwk = ref[c];
-            if (c === 0) {
-              continue;
+            if (c != 0) {
+              nwk = "SSID:" + ref[c];
             }
             _network = {};
             ref1 = nwk.split('\n');


### PR DESCRIPTION
```
WiFiControl.scanForWiFi( function(err, response) {
    if (err) console.log(error);
    console.log(response);
  });
```

Doesn´t find any wlan.
I have fixed it in my fork, so that it is working for me.
