### PR TITLE
Fix infinite loop on error conditions that are not caught

### DIFF
--- a/src/wifi-control.coffee
+++ b/src/wifi-control.coffee
@@ -498,6 +498,13 @@ module.exports =
                 success: false
                 msg: _msg
               }
+            else if error.stderr.toString().search /Error:/ != -1
+              _msg = error.stderr.toString().trim()
+              WiFiLog _msg, true
+              return {
+                success: false
+                msg: _msg
+              }
             # Ignore nmcli's add/modify errors, this is a system bug
             unless /nmcli device wifi connect/.test(COMMANDS[com])
               WiFiLog error, true


### PR DESCRIPTION
There are cases where nmcli returns other errors which are not handled by wifi-control. This can cause an infinite loop when "Waiting for connection attempt to settle" loop runs. I added a catch all which gets around this. An example of a way to reproduce these other errors is by not having permissions to create connections on the host system by the user that is running Node. Usually a user other than root.
