### PR TITLE
Replacing "device" with "dev" for outdated nmcli.

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -21,7 +21,7 @@
     autoFindInterface: function() {
       var _iface, _interface, _interfaceLine, _msg, findInterfaceCom, parsedLine;
       this.WiFiLog("Host machine is Linux.");
-      findInterfaceCom = "nmcli -m multiline device status | grep wlan";
+      findInterfaceCom = "nmcli -m multiline dev status | grep wlan";
       this.WiFiLog("Executing: " + findInterfaceCom);
       _interfaceLine = this.execSync(findInterfaceCom);
       parsedLine = parsePatterns.nmcli_line.exec(_interfaceLine.trim());
@@ -52,7 +52,7 @@
       interfaceState.power = powerStateMap[powerData.trim()];
       if (interfaceState.power) {
         foundInterface = false;
-        connectionData = this.execSync("nmcli -m multiline device status");
+        connectionData = this.execSync("nmcli -m multiline dev status");
         connectionName = null;
         ref = connectionData.split('\n');
         for (k = i = 0, len = ref.length; i < len; k = ++i) {
@@ -117,7 +117,7 @@
     },
     scanForWiFi: function() {
       var KEY, VALUE, _network, c, error, error1, i, j, k, len, len1, ln, networks, nwk, parsedLine, ref, ref1, scanResults;
-      scanResults = this.execSync("nmcli -m multiline device wifi list");
+      scanResults = this.execSync("nmcli -m multiline dev wifi list");
       networks = [];
       ref = scanResults.split('*:');
       for (c = i = 0, len = ref.length; i < len; c = ++i) {
@@ -161,7 +161,7 @@
       var COMMANDS, _msg, com, connectToAPChain, error, error1, error2, i, len, ssidExist, stdout;
       COMMANDS = {
         "delete": "nmcli connection delete \"" + _ap.ssid + "\"",
-        connect: "nmcli device wifi connect \"" + _ap.ssid + "\""
+        connect: "nmcli dev wifi connect \"" + _ap.ssid + "\""
       };
       if (_ap.password.length) {
         COMMANDS.connect += " password \"" + _ap.password + "\"";
@@ -203,7 +203,7 @@
               msg: _msg
             };
           }
-          if (!/nmcli device wifi connect/.test(COMMANDS[com])) {
+          if (!/nmcli dev wifi connect/.test(COMMANDS[com])) {
             this.WiFiLog(error, true);
             return {
               success: false,


### PR DESCRIPTION
Older OS's such as Raspbian Wheezy has a more limited version of nmcli that does not accept device as a parameter, it does accept dev though. I have also checked newer versions of nmcli and it accepts both dev and device.