### PR TITLE
Added support for non-english linux systems

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -117,7 +117,7 @@
     },
     scanForWiFi: function() {
       var KEY, VALUE, _network, c, error, error1, i, j, k, len, len1, ln, networks, nwk, parsedLine, ref, ref1, scanResults;
-      scanResults = this.execSync("nmcli -m multiline device wifi list");
+      scanResults = this.execSync("export LC_ALL=C && nmcli -m multiline device wifi list && unset LC_ALL");
       networks = [];
       ref = scanResults.split('*:');
       for (c = i = 0, len = ref.length; i < len; c = ++i) {

--- a/src/linux.coffee
+++ b/src/linux.coffee
@@ -104,7 +104,7 @@ module.exports =
     #
     # Use nmcli to list visible wifi networks.
     #
-    scanResults = @execSync "nmcli -m multiline device wifi list"
+    scanResults = @execSync "export LC_ALL=C && nmcli -m multiline device wifi list && unset LC_ALL"
     #
     # Parse the results into an array of AP objects to match
     # the structure found in node-wifiscanner2 for win32 and MacOS.


### PR DESCRIPTION
In a non-english linux system the output of the nmcli is different from the english one.
I added a little workaround that set the default locale in ascii before the command and restore the original locale after the command. 
I think this solution is easy and bulletproof.